### PR TITLE
check for null chunk center

### DIFF
--- a/src/main/java/io/pfaumc/bluemapfoliaregions/BlueMapFoliaRegionsPlugin.java
+++ b/src/main/java/io/pfaumc/bluemapfoliaregions/BlueMapFoliaRegionsPlugin.java
@@ -72,6 +72,7 @@ public class BlueMapFoliaRegionsPlugin extends JavaPlugin {
             List<Long> sections = entry.getValue();
 
             ChunkPos centerChunk = region.getCenterChunk();
+            if (centerChunk == null) continue;
             String label = "Region@" + region.getData().world.getTypeKey().location().getPath() + "[" + centerChunk.x + "," + centerChunk.z + "]";
 
             List<Vector2d> points = getSectionPoints(sections);


### PR DESCRIPTION
for some reason center chunk can be null which causes this 
```
[17:21:26 WARN]: [BlueMap-Folia-Regions] Global task for BlueMap-Folia-Regions v1.0 generated an exception
java.lang.NullPointerException: Cannot read field "e" because "centerChunk" is null
	at BlueMap-Folia-Regions-1.0.jar/io.pfaumc.bluemapfoliaregions.BlueMapFoliaRegionsPlugin.createMarkers(BlueMapFoliaRegionsPlugin.java:75) ~[BlueMap-Folia-Regions-1.0.jar:?]
	at BlueMap-Folia-Regions-1.0.jar/io.pfaumc.bluemapfoliaregions.BlueMapFoliaRegionsPlugin.updateRegionMarkets(BlueMapFoliaRegionsPlugin.java:60) ~[BlueMap-Folia-Regions-1.0.jar:?]
	at BlueMap-Folia-Regions-1.0.jar/io.pfaumc.bluemapfoliaregions.BlueMapFoliaRegionsPlugin.lambda$onBlueMapEnable$0(BlueMapFoliaRegionsPlugin.java:36) ~[BlueMap-Folia-Regions-1.0.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:179) ~[folia-1.20.6.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:37) ~[folia-1.20.6.jar:?]
	at io.papermc.paper.threadedregions.RegionizedServer.globalTick(RegionizedServer.java:293) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at io.papermc.paper.threadedregions.RegionizedServer$GlobalTickTickHandle.tickRegion(RegionizedServer.java:148) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:404) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at ca.spottedleaf.concurrentutil.scheduler.SchedulerThreadPool$TickThreadRunner.run(SchedulerThreadPool.java:525) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
[17:21:26 WARN]: [BlueMap-Folia-Regions] Global task for BlueMap-Folia-Regions v1.0 generated an exception
java.lang.NullPointerException: Cannot read field "e" because "centerChunk" is null
	at BlueMap-Folia-Regions-1.0.jar/io.pfaumc.bluemapfoliaregions.BlueMapFoliaRegionsPlugin.createMarkers(BlueMapFoliaRegionsPlugin.java:75) ~[BlueMap-Folia-Regions-1.0.jar:?]
	at BlueMap-Folia-Regions-1.0.jar/io.pfaumc.bluemapfoliaregions.BlueMapFoliaRegionsPlugin.updateRegionMarkets(BlueMapFoliaRegionsPlugin.java:60) ~[BlueMap-Folia-Regions-1.0.jar:?]
	at BlueMap-Folia-Regions-1.0.jar/io.pfaumc.bluemapfoliaregions.BlueMapFoliaRegionsPlugin.lambda$onBlueMapEnable$0(BlueMapFoliaRegionsPlugin.java:36) ~[BlueMap-Folia-Regions-1.0.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:179) ~[folia-1.20.6.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:37) ~[folia-1.20.6.jar:?]
	at io.papermc.paper.threadedregions.RegionizedServer.globalTick(RegionizedServer.java:293) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at io.papermc.paper.threadedregions.RegionizedServer$GlobalTickTickHandle.tickRegion(RegionizedServer.java:148) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:404) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at ca.spottedleaf.concurrentutil.scheduler.SchedulerThreadPool$TickThreadRunner.run(SchedulerThreadPool.java:525) ~[folia-1.20.6.jar:git-Folia-"b1bfe7b"]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]

```